### PR TITLE
Call logging middleware when an error is raised

### DIFF
--- a/lib/click_house/connection.rb
+++ b/lib/click_house/connection.rb
@@ -53,8 +53,8 @@ module ClickHouse
         conn.headers = config.headers
         conn.ssl.verify = config.ssl_verify
         conn.request(:basic_auth, config.username, config.password) if config.auth?
-        conn.response Middleware::Logging, logger: config.logger!
         conn.response Middleware::RaiseError
+        conn.response Middleware::Logging, logger: config.logger!
         conn.response :json, content_type: %r{application/json}
         conn.response Middleware::ParseCsv, content_type: %r{text/csv}
         conn.adapter config.adapter


### PR DESCRIPTION
When Clickhouse return an error, the Faraday logging middleware wasn't called. This makes it harder to debug more complex query issues,
because the DB::Exception error message only contains a subset of the query that failed.

Before:

```
[1] pry(main)> ClickHouse.connection.execute('select boom')
ClickHouse::DbException: [404] Code: 47. DB::Exception: Missing columns: 'boom' while processing query: 'SELECT boom', required columns: 'boom'. (UNKNOWN_IDENTIFIER) (version 21.12.3.32.altinitydev.arm (altinity build))
```

After:

```
I, [2022-04-01T16:49:44.657015 #49021]  INFO -- : SQL (Total: 8MS) select boom;
                                                                               I, [2022-04-01T16:49:44.657052 #49021]  INFO -- : Read: 0 rows, 0B. Written: 0 rows, 0B
ClickHouse::DbException: [404] Code: 47. DB::Exception: Missing columns: 'boom' while processing query: 'SELECT boom', required columns: 'boom'. (UNKNOWN_IDENTIFIER) (version 21.12.3.32.altinitydev.arm (altinity build))
```